### PR TITLE
save list to local storage

### DIFF
--- a/src/AddTodoForm.jsx
+++ b/src/AddTodoForm.jsx
@@ -3,10 +3,9 @@ import { useState } from "react";
 
 //added props as a parameter in the AddTodoForm function
 //took out prop and added onAddTodo as a destructured parameter in the AddTodoForm function
-const AddTodoForm = ( { onAddTodo } ) => {
+const AddTodoForm = ({ onAddTodo }) => {
   //Create new state variable named todoTitle with setter setTodoTitle and sets todoTitle to an empty string
   const [todoTitle, setTodoTitle] = useState("");
-  
 
   //function retrieves the input value from the event and updated the state using setTodoTitle
   function handleTitleChange(event) {
@@ -22,20 +21,20 @@ const AddTodoForm = ( { onAddTodo } ) => {
     const newTodo = {
       title: todoTitle,
       id: Date.now(),
-    }
-      
+    };
+
     console.log("newTodo", newTodo);
-    
+
     //Calls the onAddTodo callback prop and pass the newTodo object
     //checks if onAddTodo is provided then calls it with newTodo object
-    
+
     if (onAddTodo) {
       onAddTodo(newTodo);
     }
 
     //resets the form and clears input;
     // event.target.reset();
-    
+
     //clears the input field by resetting the state
     setTodoTitle("");
   }

--- a/src/App.css
+++ b/src/App.css
@@ -5,11 +5,11 @@
   text-align: center;
 }
 
-.todo-list-image {
+/* .todo-list-image {
   width: 300px;
   height: auto;
   padding-left: 50px;
-}
+} */
 
 .todo-list-image1 {
   width: 300px;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,44 +1,53 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 // import React from 'react';
-import TodoList from './TodoList';
-import AddTodoForm from './AddTodoForm';
-import './App.css'
-
+import TodoList from "./TodoList";
+import AddTodoForm from "./AddTodoForm";
+import "./App.css";
 
 // import todoListImage from "./assets/to-do-list.png"
-import todoListImage1 from "./assets/todo-list1.png"
+import todoListImage1 from "./assets/todo-list1.png";
 
+// creates custom hook to manage the state of the todo list, and retrieving todo list from local storage and for reusability
+const useSemiPersistentState = () => {
+  //creates a state var todoList to hold todo items and uses the function setTodoList to update todoList
+  //updates the default state to parse the value of the "savedTodoList" item
+  const [todoList, setTodoList] = useState(() => {
+    //this retrieves the value of "savedTodoList" from storage. JSON.parse takes the string and converts it to a javaScript obj or arr.
+    const savedTodoList = JSON.parse(localStorage.getItem("savedTodoList"));
+    //returns an empty array if savedTodoList is null
+    return savedTodoList || [];
+  });
 
+  // Defines a useEffect React hook with todoList as a dependency. The useEffect hook performs side effects in function components. It is being used to synchronize the "todoList" state with "localStorage".
+  useEffect(() => {
+    localStorage.setItem("savedTodoList", JSON.stringify(todoList));
+  }, [todoList]);
+
+  //returns the state var "todoList" and setter function "setTodoList" as an array
+  return [todoList, setTodoList];
+};
 
 function App() {
-
-  //creates a state var todoList to hold todo items and uses the function setTodoList to update todoList and sets todoList to an empty array
-  const [todoList, setTodoList] = useState([]);
+  //Updates App function to use the useSemiPersistentState hook
+  const [todoList, setTodoList] = useSemiPersistentState();
 
   //function to add a new todo
   function addTodo(newTodo) {
     //calls the setTodoList state setter
-    setTodoList(prevList => [
-      ...prevList,
-      newTodo,
-    ]);
+    setTodoList((prevList) => [...prevList, newTodo]);
   }
 
   return (
-    <div>
-   
-       
-        <img src={todoListImage1} className="todo-list-image1" alt="Todo List" />
-      <h1>Todo List</h1> 
-     
+    <>
+      <img src={todoListImage1} className="todo-list-image1" alt="Todo List" />
+      <h1>Todo List</h1>
+
       {/*passes addTodo as a callback handler prop named onAddTodo. This allows AddTodoForm to call addTodo when a new todo is added*/}
       <AddTodoForm onAddTodo={addTodo} />
 
-
       {/*passes todoList state as a prop named todoList to the TodoList component */}
       <TodoList todoList={todoList} />
-
-    </div>
+    </>
   );
 }
 

--- a/src/TodoList.jsx
+++ b/src/TodoList.jsx
@@ -1,22 +1,15 @@
 import React from "react";
 import TodoListItem from "./TodoListItem";
 
-// const todoList = [
-//     { id: 1, title: "Complete homework" },
-//     { id: 2, title: "Finish project" },
-//     { id: 3, title: "Go grocery shopping" },
-//   ];
-
 //added props parameter to function
 function TodoList({ todoList }) {
-
-    console.log(todoList);
+  console.log(todoList);
 
   return (
     <div>
       <ul>
         {/* changed todoList to reference props  */}
-       
+
         {todoList.map((todo) => (
           // Pass key as a prop equal to the id of the todo object
           // I passed key={todo.id} as a prop to TodoListItem

--- a/src/index.css
+++ b/src/index.css
@@ -34,6 +34,9 @@ body {
   padding-top: 20px;
 }
 
+
+
+
 h1 {
   font-size: 3.2em;
   line-height: 1.1;


### PR DESCRIPTION
Saved list to local browser storage so list items will stay even when page is refreshed.
-Created a useEffect hook with todoList as a dependency. This hook performs side effects in the function components to synchronize the "todoList" state with "localStorage".
-Used JSON.stringify to convert "todoList" to a string before saving it in "localStorage".

 -Used "localStorage.getItem()" to update the default state for "todoList" to read the "savedTodoList" item from "localStorage"
-Used JSON.parse() to take the string and convert it to a javaScript object or array.

-Created a new function "useSemiPersistentState" to create a new custom hook. This will retrieve the to do list from the local storage and is reusable.
-Created state variable "todoList" to hold the todo items and use the function "setTodoList" to update "todoList"
-Added return "savedTodoList" to return the "todoList" state variable and setter in an array.

-Added in fragments to my divs ex <> </>


